### PR TITLE
interfaceIp setting does not work.

### DIFF
--- a/Helper/OSCCommunicator/Sender.cs
+++ b/Helper/OSCCommunicator/Sender.cs
@@ -12,18 +12,34 @@ namespace streamdeck_totalmix
     {
         public static Task Send(String name, Single value, String ip, Int32 port)
         {
+            // Binding address. Technically we can leave this as the any address, but it doesn't really matter.
+            IPAddress LocalIP = IPAddress.Loopback;
+            // This is the ip address we are going to send to
+            IPAddress RemoteIP;
+            // Attempt to parse the input address. If we fail to parse, fall back to the loopback.
+            if (ip != null && IPAddress.TryParse(ip, out RemoteIP))
+            {
+                // If it's not the loopback/localhost address, then set the LocalIP to the any address
+                if (!IPAddress.IsLoopback(RemoteIP))
+                {
+                    LocalIP = IPAddress.Any;
+                }
+            }
+            else
+            {
+                // If tryparse ever fails, RemoteIP will be null, so remember to set a valid address here.
+                RemoteIP = IPAddress.Loopback;
+            }
+
             OscSender sender = null;
-            try { sender = new OscSender(address: IPAddress.Loopback, localPort: 0, remotePort: port); }
+            try { sender = new OscSender(local: LocalIP, localPort: 0, remote: RemoteIP, remotePort: port); }
             catch (Exception ex)
             {
                 Logger.Instance.LogMessage(TracingLevel.INFO, "Sender:  new OscSender: " + ex.Message);
                 sender.Dispose();
                 sender = null;
             }
-            finally { sender = new OscSender(address: IPAddress.Loopback, localPort: 0, remotePort: port); }
-
-            // This is the ip address we are going to send to
-            IPAddress address = IPAddress.Parse(ip);
+            finally { sender = new OscSender(local: LocalIP, localPort: 0, remote: RemoteIP, remotePort: port); }
 
             try
             {


### PR DESCRIPTION
The ip input value goes unused, and needs to be added to the original constructor otherwise the message will not be sent. Added address verification for input interfaceIp setting.

Attached pull request will allow for messages to be sent outside of the machine the steamdeck is connected to. Tested on local network.